### PR TITLE
Fix historicdutchweather

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Ignore log files as long as they follow the naming scheme below:
 log_*.txt
+
+# Ignore historic dutch weather install
+/src/historicdutchweather/


### PR DESCRIPTION
Fix historicdutchweather dependency.

This dependency was IN this repo, which was not supposed to happen. It is not in the gitignore, so it should not happen again.