### PR TITLE
Dataretrieval from twomes v2 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Twomes inverse grey-box modelling and analysis tools for homes and utility buildings
-This repository contains source code for the Twomes digital twin heat balance models and inverse-grey-box analysis tools, based on [GEKKO Python](https://github.com/BYU-PRISM/GEKKO). This analysis software can be regarded as a particular form of physics informed machine learning for automated estimation of crucial parameters of buildings, installations and comfort needs in individual homes and utility buildings based on time-series monitoring data.
+# NeedForHeat analysis tools for homes and utility buildings
+This repository contains source code for the NeedForHeat heat balance models and analysis tools, based on [GEKKO Python](https://github.com/BYU-PRISM/GEKKO). This analysis software can be regarded as a particular form of physics informed machine learning for automated estimation of crucial parameters of buildings, installations and comfort needs in individual homes and utility buildings based on time-series monitoring data.
 
 ## Table of contents
 * [General info](#general-info)
@@ -15,18 +15,24 @@ This repository contains source code for the Twomes digital twin heat balance mo
 
 This repository contains the GEKKO Python-based implementation of inverse grey-box analysis software. The purpose of this sofware is to (help) speedup the energy transition, in particular the heating transition. 
 
-We developed this software in the [Twomes](https://edu.nl/9fv8w) project (to learn building parameters) and the [Brains4Buildings](https://edu.nl/kynxd) project (to learn from the relation between occupancy, ventilation rates and CO<sub>2</sub> concentration). This reposotory contains data for virtual homes and virtual rooms that were used to verify the proper implementation of the GEKKO models. 
+This software was developed in the context of multiple projects:
 
-The data we collected, including a metadata can be found in these related repositories:
-- [twomes-dataset-assendorp2021](https://github.com/energietransitie/twomes-dataset-assendorp2021).
-- [brains4buildings-dataset-windesheim2022](https://github.com/energietransitie/brains4buildings-dataset-windesheim2022).
+* [Twomes](https://edu.nl/9fv8w), our first research project aimed at building digital twins that used inverse grey-box modelling to learn physical building parameters;
+* [Brains4Buildings](https://edu.nl/kynxd), a research project in which we explored relation between occupancy, ventilation rates and CO<sub>2</sub> concentration;
+* [REDUCEDHEATCARB](https://edu.nl/gutuc), a research project in which we extend the models from these earlier projects with models for ventilation heat loss, wind-dependent infiltration heat loss and a model that seprates heat generation (in a boiler orand/ heat pump) from heat distribution (e.g. via hydronic radiators). 
+
+This repository also contains synthetic home data and synthetic room data that we generated used to verify the proper implementation of the GEKKO models. 
+
+Field data, including a metadata can be found in these related repositories:
+
+* [twomes-dataset-assendorp2021](https://github.com/energietransitie/twomes-dataset-assendorp2021).
+* [brains4buildings-dataset-windesheim2022](https://github.com/energietransitie/brains4buildings-dataset-windesheim2022).
 
 ## Prerequisites
 
-Both for deplopying of and developing for the software in this repository, you can use a [JupyterLab](https://jupyter.org/) environment on your local machine. Other environments, such as [PyCharm](https://www.jetbrains.com/pycharm/download/#section=windows) and [Visual Studio Code](https://code.visualstudio.com/) may work as well, but we do not include documentation for this here. 
+We recommend to [install and use JupyterLab in a docker container on a server](https://github.com/energietransitie/twomes-backoffice-configuration#jupyterlab).
 
-**Note**
-As an alternative, you can also [install and use JupyterLab in a docker container on a server](https://github.com/energietransitie/twomes-backoffice-configuration#jupyterlab).
+As an alternative, you can use a [JupyterLab](https://jupyter.org/) environment on your local machine. Other environments, such as [PyCharm](https://www.jetbrains.com/pycharm/download/#section=windows) and [Visual Studio Code](https://code.visualstudio.com/) may work as well, but we do not include documentation for this here. 
 
 To use JupyterLab on your local machine, make sure you have the following software properly installed and configured on your machine:
 
@@ -91,12 +97,15 @@ This section describes how you can change the source code. You can do this using
 Should you find any issues or bugs in our code, please report them via the [issues](https://github.com/energietransitie/twomes-inverse-grey-box-analysis/issues) tab of this repository.
 
 To change the code, we recommend:
-- Try out your changes using the various `.ipynb ` files from the [`examples`](/examples) folder. The section [Deploying](#deploying) contains a high level description of these files.
-- Migrate stable code to functions in Python files.
-- Should you have extensions or bug fixes that could be useful for other users of the repository as well, please fork this reposotory and make a Pull Request on this repository. 
+
+* Try out your changes using the various `.ipynb ` files from the [`examples`](/examples) folder. The section [Deploying](#deploying) contains a high level description of these files.
+* Migrate stable code to functions in Python files.
+* Should you have extensions or bug fixes that could be useful for other users of the repository as well, please fork this reposotory and make a Pull Request on this repository. 
 
 ## Features
-Features include:
+
+Current features include:
+
 * data extraction;
 * data preprocessing: measurement outlier removal and interpolation;
 * `learn_home_parameters()` function in [`inversegreyboxmodel.py`](/analysis/inversegreyboxmodel.py) that uses a GEKKO model and code to learn building model parameters such as specific heat loss [W/K], thermal intertia [h], thermal ass [Wh/K] and apparent solar aperture [m<sup>2</sup>] of a building;
@@ -105,6 +114,7 @@ Features include:
 	* apparent infiltration area [m<sup>2</sup>] and occupancy [p] from from CO<sub>2</sub> concentration [ppm] and ventilation rates [m<sup>3</sup>/h]  time series data;
 
 To-do:
+
 * update code in the `learn_home_parameters()` function to align with the newer code and preprocessing tools used in the `learn_room_parameters()` function;
 * extend GEKKO model in `learn_home_parameters()` with installation model details to learn installation parameters;
 * add 'dynamic' measurement outlier removal for measurement time series before interpolation, i.e. a rolling window outlier removal procedure, similar to a [hampel filter](https://pypi.org/project/hampel/) but working on non-equidistant time-series data and using a duration as a time window;
@@ -119,8 +129,8 @@ This software is available under the [Apache 2.0 license](/LICENSE), Copyright 2
 
 ## Credits
 This software is a collaborative effort of:
-* Hossein Rahmani · [@HosseinRahmani64](https://github.com/HosseinRahmani64)
 * Henri ter Hofte · [@henriterhofte](https://github.com/henriterhofte) · Twitter [@HeNRGi](https://twitter.com/HeNRGi)
+* Hossein Rahmani · [@HosseinRahmani64](https://github.com/HosseinRahmani64)
 
 It is partially based on earlier work by the following students:
 * Casper Bloemendaal · [@Bloemendaal](https://github.com/Bloemendaal)

--- a/data/measurements.py
+++ b/data/measurements.py
@@ -147,12 +147,14 @@ class Measurements:
                            ]
                           )
         
-        df = (df
-                .drop_duplicates(subset=['id', 'timestamp','device_type', 'device_name', 'property', 'value'], keep='first')
-                .rename(columns = {'device_type':'source'}) 
-                .set_index(['id', 'device_name', 'source', 'timestamp', 'property'])
-                .tz_convert(tz_building, level='timestamp')
-               )
+        if not df.empty:
+            df = (df
+                    .drop_duplicates(subset=['id', 'timestamp','device_type', 'device_name', 'property', 'value'], keep='first')
+                    .rename(columns = {'device_type':'source'}) 
+                    .set_index(['id', 'device_name', 'source', 'timestamp', 'property'])
+                    .tz_convert(tz_building, level='timestamp')
+                   )
+
         if property_rename is not None:
             return df.rename(index=property_rename).sort_index()
 
@@ -265,14 +267,14 @@ class Measurements:
                            ]
                           )
         
-        #TODO: handle errors when dataframa is empty
         #TODO: handle campaigns where timezone may be different per building
-        df = (df
-                .drop_duplicates(subset=['id', 'timestamp','device_type', 'device_name', 'property', 'value'], keep='first')
-                .rename(columns = {'device_type':'source'}) 
-                .set_index(['id', 'device_name', 'source', 'timestamp', 'property'])
-                .tz_convert(tz_building, level='timestamp')
-               )
+        if not df.empty:
+            df = (df
+                    .drop_duplicates(subset=['id', 'timestamp','device_type', 'device_name', 'property', 'value'], keep='first')
+                    .rename(columns = {'device_type':'source'}) 
+                    .set_index(['id', 'device_name', 'source', 'timestamp', 'property'])
+                    .tz_convert(tz_building, level='timestamp')
+                   )
         return df.sort_index()
 
         

--- a/data/measurements.py
+++ b/data/measurements.py
@@ -227,35 +227,23 @@ class Measurements:
             case 0:
                 logging.warning('empty list of ids')
             case 1:
-                sql_query = sql_query + " WHERE a.pseudonym = "+ str(ids[0])
+                sql_query = sql_query + " WHERE a.id = "+ str(ids[0])
             case _:
-                sql_query = sql_query + " WHERE a.pseudonym IN "+ f'{tuple(map(str, ids))}'        
+                sql_query = sql_query + " WHERE a.id IN "+ f'{tuple(map(str, ids))}'        
         
         match len(db_properties):
-            case 0: 
-                logging.warning('empty list of property names')
-            case 1:
-                sql_query_properties = "SELECT id FROM property WHERE name = '"+ db_properties[0] + "'"
-                df_properties = pd.read_sql(sql=text(sql_query_properties), con=db.connect())
-                logging.info(f'first_day: {sql_query_properties}')
-            case _:
-                sql_query_properties = "SELECT id FROM property WHERE name IN "+ str(tuple(db_properties))
-                df_properties = pd.read_sql(sql=text(sql_query_properties), con=db.connect())
-                logging.info(f'first_day: {sql_query_properties}')
-            
-        match len(df_properties.index):
             case 0:
                 logging.warning('empty list of properties found')
             case 1:
-                sql_query = sql_query + " AND p.id = "+ str(df_properties['id'].iloc[0])
+                sql_query = sql_query + " AND p.name = '"+ str(db_properties[0]) + "'"
             case _:
-                sql_query = sql_query + " AND p.id IN "+ str(tuple(df_properties['id']))
+                sql_query = sql_query + " AND p.name IN "+ str(tuple(db_properties)) 
 
         if first_day is not None: 
-            sql_query = sql_query + " AND m.timestamp >= "+ first_str
+            sql_query = sql_query + " AND m.time >= "+ first_str
 
         if last_day is not None: 
-            sql_query = sql_query + " AND m.timestamp <= "+ last_str 
+            sql_query = sql_query + " AND m.time <= "+ last_str 
 
         logging.info(sql_query.replace('\n',' '))
 
@@ -271,8 +259,7 @@ class Measurements:
             df = pd.concat([df,chunk.astype({'id':'category',
                                              'device_name':'category',
                                              'device_type':'category',
-                                             'property':'category',
-                                             'unit':'category'
+                                             'property':'category'
                                             }
                                            )
                            ]

--- a/examples/NeedForHeatExtractionBackup.ipynb
+++ b/examples/NeedForHeatExtractionBackup.ipynb
@@ -1,0 +1,426 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# REDUCEDHEATCARB data extraction and backup\n",
+    "\n",
+    "This JupyterLabs notebook can be used download raw data from a twomes_v2 database (see also [more information how to setup a backoffice server](https://github.com/energietransitie/twomes-backoffice-configuration#jupyterlab)).\n",
+    "\n",
+    "Don't forget to install the requirements listed in [requirements.txt](../requirements.txt) first!\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Setting the stage\n",
+    "\n",
+    "First several imports and variables need to be defined\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imports and generic settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta\n",
+    "import pytz\n",
+    "import pylab as plt\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# usually, two decimals suffice for displaying DataFrames (NB internally, precision may be higher)\n",
+    "pd.options.display.precision = 2\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('../data/')\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "import gc\n",
+    "\n",
+    "from measurements import Measurements\n",
+    "\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "\n",
+    "import logging\n",
+    "logging.basicConfig(level=logging.INFO, \n",
+    "                    format='%(asctime)s %(levelname)-8s %(message)s',\n",
+    "                    datefmt='%Y-%m-%d %H:%M:%S',\n",
+    "                    filename='log.txt',\n",
+    "                   )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining which homes, which period \n",
+    "\n",
+    "- which `homes` \n",
+    "- what the location and timezone is of those homes (currently, we only support one location and timezone for a batch of homes) \n",
+    "- from which `start_day` to which `end_day` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: change weather interpolation location to a location per home (rounded to H3 coodrinates at a high level);\n",
+    "# the location below is the center of Assendorp neighbourhood in Zwolle\n",
+    "lat, lon = 52.50655, 6.09961\n",
+    "\n",
+    "# timezone: \n",
+    "timezone_database = 'UTC'\n",
+    "timezone_homes = 'Europe/Amsterdam'\n",
+    "\n",
+    "# Period: maximum period of datacollection\n",
+    "first_day = pytz.timezone(timezone_homes).localize(datetime(2023, 12, 8))\n",
+    "last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 4, 1))\n",
+    "\n",
+    "# Period: Shorter period with suitable weather and lots of homes with measurements.\n",
+    "# first_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 12))\n",
+    "# last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 25))\n",
+    "\n",
+    "\n",
+    "# Homes: full set of subjects that started and did not stop\n",
+    "homes_full = [7, 9, 12, 14, 17, 20, 21, 24, 26, 28, 31, 32, 36, 39, 40, 41, 42, 45, 49, 53, 38, 13, 44, 43]\n",
+    "\n",
+    "# Homes: subset that satisfy 6 criteria: 1_app_activated__bool, 2a_p1_activated__bool, 2b_woonkamermodule_activated__bool, 3b_completed_onboarding__bool, 4a_enelogic_auth__bool, 4b_enelogic_data_bool\n",
+    "homes_all = [7, 9, 12, 14, 17, 20, 21, 24, 26, 28, 31, 32, 36, 39, 40, 41, 42, 45, 49, 53]\n",
+    "\n",
+    "#Homes: 3 homes (for testing multi-home data retrieval)\n",
+    "homes_3 = [7, 26, 53]\n",
+    "\n",
+    "# Homes: single home (for testing purposes)\n",
+    "homes_single = [7]\n",
+    "\n",
+    "\n",
+    "# Properties: a single one\n",
+    "needforheat_single_property_type = {\n",
+    "    'co2__ppm' : 'float32'\n",
+    "}\n",
+    "needforheat_single_property = list(needforheat_single_property_type.keys())\n",
+    "\n",
+    "\n",
+    "# Properties: limited set\n",
+    "needforheat_limited_properties_types = {\n",
+    "    'temp_in__degC' : 'float32',\n",
+    "    'co2__ppm' : 'float32',\n",
+    "    'e_use_lo_cum__kWh' : 'float64',\n",
+    "    'e_use_hi_cum__kWh' : 'float64',\n",
+    "    'e_ret_lo_cum__kWh' : 'float64',\n",
+    "    'e_ret_hi_cum__kWh' : 'float64',\n",
+    "    'g_use_cum__m3' : 'float64',\n",
+    "    'occupancy__p' : 'Int8'\n",
+    "}\n",
+    "needforheat_limited_properties = list(needforheat_limited_properties_types.keys())\n",
+    "\n",
+    "\n",
+    "# Properties:  full set\n",
+    "needforheat_full_properties_types = {\n",
+    "    'temp_in__degC' : 'float32',\n",
+    "    'co2__ppm' : 'float32',\n",
+    "    'rel_humidity__0' : 'float32',\n",
+    "    'occupancy__p' : 'Int8',\n",
+    "    'onboarded__p' : 'Int8',\n",
+    "    'heartbeat' : 'Int16'\n",
+    "    'e_use_lo_cum__kWh' : 'float64',\n",
+    "    'e_use_hi_cum__kWh' : 'float64',\n",
+    "    'e_ret_lo_cum__kWh' : 'float64',\n",
+    "    'e_ret_hi_cum__kWh' : 'float64',\n",
+    "    'g_use_cum__m3' : 'float64',\n",
+    "    'meter_code__str': 'str',\n",
+    "    'dsmr_version__0', 'float32',\n",
+    "    'e_use_cum__kWh' : 'float64',\n",
+    "    'e_ret_cum__kWh' : 'float64'\n",
+    "}\n",
+    "needforheat_full_properties = list(needforheat_full_properties_types.keys())\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting measurements: 1 property, 1 home"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "%autoreload 2\n",
+    "df_meas= Measurements.get_needforheat_measurements(\n",
+    "    homes_single,\n",
+    "    first_day, last_day,\n",
+    "    needforheat_single_property,\n",
+    "    timezone_database, timezone_homes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get measuremens for more properties for 3 homes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "df_meas= Measurements.get_needforheat_measurements(\n",
+    "    homes_3,\n",
+    "    first_day, last_day,\n",
+    "    needforheat_limited_properties,\n",
+    "    timezone_database, timezone_homes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get all measurements for all homes and write to parquet file(s)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get measurements for all properties for 23 homes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "df_meas = Measurements.get_needforheat_measurements(\n",
+    "    homes_all,\n",
+    "    first_day, last_day,\n",
+    "    needforheat_full_properties,\n",
+    "    timezone_database, timezone_homes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_meas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Writing raw measurements to a parquet file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "df_meas.to_parquet('needforheat_raw_measurements.parquet', index=True, engine='pyarrow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Write raw measurements per home to parquet files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "for home_id in tqdm(list(df_meas.index.unique(level='id'))):\n",
+    "    df_meas.xs(home_id, drop_level=False).to_parquet(f'{home_id}_raw_measurements.parquet', index=True, engine='pyarrow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Put properties in separate columns, apply types and write parquet file(s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# unstacking takes the entire NeedForHeat dataset uses XX GB memory, so we have to do it home by home\n",
+    "del df_meas\n",
+    "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Writing raw properties per home to a parquet file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "df_prop = pd.DataFrame()\n",
+    "\n",
+    "for home_id in tqdm(homes_all):\n",
+    "    df_prop_home = Measurements.to_properties(\n",
+    "        pd.read_parquet(f'{home_id}_raw_measurements.parquet', engine='pyarrow'),\n",
+    "        needforheat_full_properties_types\n",
+    "    )\n",
+    "    df_prop_home.to_parquet(f'{home_id}_raw_properties.parquet', index=True, engine='pyarrow')\n",
+    "    df_prop = pd.concat([df_prop, df_prop_home])   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_prop.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_prop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Writing raw properties to a parquet file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "df_prop.to_parquet('needforheat_raw_properties.parquet', index=True, engine='pyarrow')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/NeedForHeatExtractionBackup.ipynb
+++ b/examples/NeedForHeatExtractionBackup.ipynb
@@ -93,12 +93,12 @@
     "timezone_homes = 'Europe/Amsterdam'\n",
     "\n",
     "# Period: maximum period of datacollection\n",
-    "first_day = pytz.timezone(timezone_homes).localize(datetime(2023, 12, 8))\n",
-    "last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 4, 1))\n",
+    "# first_day = pytz.timezone(timezone_homes).localize(datetime(2023, 12, 8))\n",
+    "# last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 4, 1))\n",
     "\n",
     "# Period: Shorter period with suitable weather and lots of homes with measurements.\n",
-    "# first_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 12))\n",
-    "# last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 25))\n",
+    "first_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 12))\n",
+    "last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 25))\n",
     "\n",
     "\n",
     "# Homes: full set of subjects that started and did not stop\n",
@@ -142,14 +142,14 @@
     "    'rel_humidity__0' : 'float32',\n",
     "    'occupancy__p' : 'Int8',\n",
     "    'onboarded__p' : 'Int8',\n",
-    "    'heartbeat' : 'Int16'\n",
+    "    'heartbeat' : 'Int16',\n",
     "    'e_use_lo_cum__kWh' : 'float64',\n",
     "    'e_use_hi_cum__kWh' : 'float64',\n",
     "    'e_ret_lo_cum__kWh' : 'float64',\n",
     "    'e_ret_hi_cum__kWh' : 'float64',\n",
     "    'g_use_cum__m3' : 'float64',\n",
     "    'meter_code__str': 'str',\n",
-    "    'dsmr_version__0', 'float32',\n",
+    "    'dsmr_version__0': 'float32',\n",
     "    'e_use_cum__kWh' : 'float64',\n",
     "    'e_ret_cum__kWh' : 'float64'\n",
     "}\n",
@@ -167,15 +167,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "homes = homes_single\n",
+    "properties = needforheat_single_property\n",
+    "types = needforheat_single_property_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%%time \n",
     "%autoreload 2\n",
     "df_meas= Measurements.get_needforheat_measurements(\n",
-    "    homes_single,\n",
+    "    homes,\n",
     "    first_day, last_day,\n",
-    "    needforheat_single_property,\n",
+    "    properties,\n",
     "    timezone_database, timezone_homes)"
    ]
   },
@@ -207,14 +220,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "homes = homes_3\n",
+    "properties = needforheat_limited_properties\n",
+    "types = needforheat_limited_properties_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time \n",
+    "%autoreload 2\n",
     "df_meas= Measurements.get_needforheat_measurements(\n",
-    "    homes_3,\n",
+    "    homes,\n",
     "    first_day, last_day,\n",
-    "    needforheat_limited_properties,\n",
+    "    properties,\n",
     "    timezone_database, timezone_homes)"
    ]
   },
@@ -256,11 +285,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "homes = homes_all\n",
+    "properties = needforheat_full_properties\n",
+    "types = needforheat_full_properties_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%%time \n",
-    "df_meas = Measurements.get_needforheat_measurements(\n",
-    "    homes_all,\n",
+    "%autoreload 2\n",
+    "df_meas= Measurements.get_needforheat_measurements(\n",
+    "    homes,\n",
     "    first_day, last_day,\n",
-    "    needforheat_full_properties,\n",
+    "    properties,\n",
     "    timezone_database, timezone_homes)"
    ]
   },
@@ -355,13 +396,27 @@
     "%%time\n",
     "df_prop = pd.DataFrame()\n",
     "\n",
-    "for home_id in tqdm(homes_all):\n",
+    "for home_id in tqdm(homes):\n",
     "    df_prop_home = Measurements.to_properties(\n",
     "        pd.read_parquet(f'{home_id}_raw_measurements.parquet', engine='pyarrow'),\n",
-    "        needforheat_full_properties_types\n",
+    "        types\n",
     "    )\n",
+    "    # Convert column names to strings\n",
+    "    df_prop_home.columns = df_prop_home.columns.astype(str)\n",
     "    df_prop_home.to_parquet(f'{home_id}_raw_properties.parquet', index=True, engine='pyarrow')\n",
     "    df_prop = pd.concat([df_prop, df_prop_home])   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Write DataFrame to Parquet\n",
+    "df_prop_home.to_parquet(f'{home_id}_raw_properties.parquet', index=True, engine='pyarrow')"
    ]
   },
   {

--- a/examples/NeedForHeatExtractionBackup.ipynb
+++ b/examples/NeedForHeatExtractionBackup.ipynb
@@ -9,9 +9,9 @@
     "# REDUCEDHEATCARB data extraction and backup\n",
     "\n",
     "This JupyterLabs notebook can be used download raw data from a twomes_v2 database (see also [more information how to setup a backoffice server](https://github.com/energietransitie/twomes-backoffice-configuration#jupyterlab)).\n",
-    "\n",
     "Don't forget to install the requirements listed in [requirements.txt](../requirements.txt) first!\n",
-    "\n"
+    "\n",
+    "Make sure you have an Excel file pseudonyms.xlsx with columns 'pseudonym' and 'account_id. which define the mapping.\n"
    ]
   },
   {
@@ -101,19 +101,6 @@
     "last_day = pytz.timezone(timezone_homes).localize(datetime(2024, 2, 25))\n",
     "\n",
     "\n",
-    "# Homes: full set of subjects that started and did not stop\n",
-    "homes_full = [7, 9, 12, 14, 17, 20, 21, 24, 26, 28, 31, 32, 36, 39, 40, 41, 42, 45, 49, 53, 38, 13, 44, 43]\n",
-    "\n",
-    "# Homes: subset that satisfy 6 criteria: 1_app_activated__bool, 2a_p1_activated__bool, 2b_woonkamermodule_activated__bool, 3b_completed_onboarding__bool, 4a_enelogic_auth__bool, 4b_enelogic_data_bool\n",
-    "homes_all = [7, 9, 12, 14, 17, 20, 21, 24, 26, 28, 31, 32, 36, 39, 40, 41, 42, 45, 49, 53]\n",
-    "\n",
-    "#Homes: 3 homes (for testing multi-home data retrieval)\n",
-    "homes_3 = [7, 26, 53]\n",
-    "\n",
-    "# Homes: single home (for testing purposes)\n",
-    "homes_single = [7]\n",
-    "\n",
-    "\n",
     "# Properties: a single one\n",
     "needforheat_single_property_type = {\n",
     "    'co2__ppm' : 'float32'\n",
@@ -158,6 +145,45 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load Excel file into DataFrame\n",
+    "df_pseudonym_mapping = pd.read_excel('pseudonyms.xlsx')\n",
+    "\n",
+    "# Create a dictionary mapping pseudonyms to account_ids\n",
+    "pseudonym_to_account_id = dict(zip(df_pseudonym_mapping['pseudonym'], df_pseudonym_mapping['account_id']))\n",
+    "\n",
+    "# Create a dictionary mapping account_ids to pseudonyms\n",
+    "account_id_to_pseudonym = dict(zip(df_pseudonym_mapping['account_id'], df_pseudonym_mapping['pseudonym']))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Homes: full set of subjects that started and did not stop\n",
+    "homes_full = [401632, 403603, 404873, 410260, 412715, 424197, 429011, 430062, 434931, 438708, 440152, 444964, 449134, 450051, 450298, 456638, 458000, 458852, 478667, 483173, 487126, 487289, 494233, 495906]\n",
+    "\n",
+    "# Homes: subset that satisfy 6 criteria: 1_app_activated__bool, 2a_p1_activated__bool, 2b_woonkamermodule_activated__bool, 3b_completed_onboarding__bool, 4a_enelogic_auth__bool, 4b_enelogic_data_bool\n",
+    "homes_all = [401632, 403603, 404873, 410260, 412715, 424197, 429011, 430062, 434931, 444964, 449134, 450298, 456638, 458000, 458852, 478667, 483173, 487126, 494233, 495906]\n",
+    "\n",
+    "#Homes: 3 homes (for testing multi-home data retrieval)\n",
+    "homes_3 = [401632, 410260, 424197]\n",
+    "\n",
+    "# Homes: single home (for testing purposes)\n",
+    "homes_single = [424197]\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -186,10 +212,11 @@
     "%%time \n",
     "%autoreload 2\n",
     "df_meas= Measurements.get_needforheat_measurements(\n",
-    "    homes,\n",
+    "    [pseudonym_to_account_id[pseudonym] for pseudonym in homes],\n",
     "    first_day, last_day,\n",
     "    properties,\n",
-    "    timezone_database, timezone_homes)"
+    "    timezone_database, timezone_homes)\n",
+    "df_meas.index = df_meas.index.set_levels(df_meas.index.levels[0].map(account_id_to_pseudonym), level=0)"
    ]
   },
   {
@@ -204,7 +231,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df_meas"
@@ -241,10 +270,11 @@
     "%%time \n",
     "%autoreload 2\n",
     "df_meas= Measurements.get_needforheat_measurements(\n",
-    "    homes,\n",
+    "    [pseudonym_to_account_id[pseudonym] for pseudonym in homes],\n",
     "    first_day, last_day,\n",
     "    properties,\n",
-    "    timezone_database, timezone_homes)"
+    "    timezone_database, timezone_homes)\n",
+    "df_meas.index = df_meas.index.set_levels(df_meas.index.levels[0].map(account_id_to_pseudonym), level=0)"
    ]
   },
   {
@@ -269,20 +299,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get all measurements for all homes and write to parquet file(s)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Get measurements for all properties for 23 homes"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "homes = homes_all\n",
@@ -299,10 +324,11 @@
     "%%time \n",
     "%autoreload 2\n",
     "df_meas= Measurements.get_needforheat_measurements(\n",
-    "    homes,\n",
+    "    [pseudonym_to_account_id[pseudonym] for pseudonym in homes] ,\n",
     "    first_day, last_day,\n",
     "    properties,\n",
-    "    timezone_database, timezone_homes)"
+    "    timezone_database, timezone_homes)\n",
+    "df_meas.index = df_meas.index.set_levels(df_meas.index.levels[0].map(account_id_to_pseudonym), level=0)"
    ]
   },
   {
@@ -321,6 +347,13 @@
    "outputs": [],
    "source": [
     "df_meas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write to parquet file(s)"
    ]
   },
   {
@@ -373,7 +406,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# unstacking takes the entire NeedForHeat dataset uses XX GB memory, so we have to do it home by home\n",
+    "# unstacking of the entire NeedForHeat dataset uses a lot of memory, socautiously do it home by home\n",
     "del df_meas\n",
     "gc.collect()"
    ]
@@ -405,18 +438,6 @@
     "    df_prop_home.columns = df_prop_home.columns.astype(str)\n",
     "    df_prop_home.to_parquet(f'{home_id}_raw_properties.parquet', index=True, engine='pyarrow')\n",
     "    df_prop = pd.concat([df_prop, df_prop_home])   "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Write DataFrame to Parquet\n",
-    "df_prop_home.to_parquet(f'{home_id}_raw_properties.parquet', index=True, engine='pyarrow')"
    ]
   },
   {
@@ -455,6 +476,13 @@
     "%%time \n",
     "df_prop.to_parquet('needforheat_raw_properties.parquet', index=True, engine='pyarrow')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/NeedForHeatExtractionBackup.ipynb
+++ b/examples/NeedForHeatExtractionBackup.ipynb
@@ -11,7 +11,7 @@
     "This JupyterLabs notebook can be used download raw data from a twomes_v2 database (see also [more information how to setup a backoffice server](https://github.com/energietransitie/twomes-backoffice-configuration#jupyterlab)).\n",
     "Don't forget to install the requirements listed in [requirements.txt](../requirements.txt) first!\n",
     "\n",
-    "Make sure you have an Excel file pseudonyms.xlsx with columns 'pseudonym' and 'account_id. which define the mapping.\n"
+    "Make sure you have an Excel file pseudonyms.xlsx with columns 'pseudonym' and 'account_id', which define the mapping.\n"
    ]
   },
   {
@@ -20,7 +20,7 @@
     "tags": []
    },
    "source": [
-    "## Setting the stage\n",
+    "## Set the stage\n",
     "\n",
     "First several imports and variables need to be defined\n"
    ]
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Defining which homes, which period \n",
+    "### Define which homes, which period \n",
     "\n",
     "- which `homes` \n",
     "- what the location and timezone is of those homes (currently, we only support one location and timezone for a batch of homes) \n",
@@ -187,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getting measurements: 1 property, 1 home"
+    "## Get measurements for 1 property, 1 home"
    ]
   },
   {
@@ -362,7 +362,7 @@
     "tags": []
    },
    "source": [
-    "### Writing raw measurements to a parquet file"
+    "### Write raw measurements to a parquet file"
    ]
   },
   {
@@ -417,7 +417,7 @@
     "tags": []
    },
    "source": [
-    "### Writing raw properties per home to a parquet file"
+    "### Write raw properties per home to a parquet file"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "tags": []
    },
    "source": [
-    "### Writing raw properties to a parquet file"
+    "### Write raw properties to a parquet file"
    ]
   },
   {

--- a/examples/NeedForHeat_Parquet_to_CSV.ipynb
+++ b/examples/NeedForHeat_Parquet_to_CSV.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b8e351d3-620f-45ea-82f0-18b8a8ebf2c5",
+   "metadata": {},
+   "source": [
+    "## Write to zipped CSV files\n",
+    "> WARNING: this might take hours!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baa708ab-f1ac-418f-9d2e-208e1b1c53d3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Write raw measurements per home to zipped CSV files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a29fb076-a8a4-4f9e-b1fb-986b25590521",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../data/')\n",
+    "import pandas as pd\n",
+    "from measurements import Measurements\n",
+    "from tqdm.notebook import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ca12f62-59ff-46ef-847d-7368cae350a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Homes: full set of subjects that started and did not stop\n",
+    "homes_full = [401632, 403603, 404873, 410260, 412715, 424197, 429011, 430062, 434931, 438708, 440152, 444964, 449134, 450051, 450298, 456638, 458000, 458852, 478667, 483173, 487126, 487289, 494233, 495906]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77664773-92dd-44cb-994e-0532b8f0ca90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "homes = homes_full"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d85f5b5-f438-49fe-81e4-1988cad39aa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "for home_id in tqdm(homes):\n",
+    "    try:\n",
+    "        df_meas_home =  pd.read_parquet(\n",
+    "            f'{home_id}_raw_measurements.parquet', \n",
+    "            engine='pyarrow',\n",
+    "            use_nullable_dtypes=True\n",
+    "        )\n",
+    "        df_meas_home.to_csv(\n",
+    "            f'{home_id}_raw_measurements.zip',\n",
+    "            encoding='utf-8',\n",
+    "            compression= dict(method='zip',\n",
+    "                              archive_name=f'{home_id}_raw_measurements.csv'),\n",
+    "            date_format='%Y-%m-%dT%H:%M:%S%z'\n",
+    "        )\n",
+    "    except FileNotFoundError as e:\n",
+    "        print(f\"Error: {e}. Skipping file {home_id}_raw_measurements.parquet.\")\n",
+    "        continue        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35275ef1-ac60-4242-a14a-75647c7c9b05",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Write raw properties per home to zipped CSV files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05e9b31f-fba3-4ce6-a0f2-f3ebe296e9c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time \n",
+    "for home_id in tqdm(homes):\n",
+    "    try:\n",
+    "        df_prop_home =  pd.read_parquet(\n",
+    "            f'{home_id}_raw_properties.parquet',\n",
+    "            engine='pyarrow'\n",
+    "        )\n",
+    "        obj_cols = df_prop_home.select_dtypes(include=['object']).columns\n",
+    "        df_prop_home[obj_cols] = df_prop_home[obj_cols].replace('nan', None)\n",
+    "        df_prop_home.to_csv(\n",
+    "            f'{home_id}_raw_properties.zip',\n",
+    "            encoding='utf-8',\n",
+    "            compression= dict(method='zip',\n",
+    "                              archive_name=f'{home_id}_raw_properties.csv'),\n",
+    "            date_format='%Y-%m-%dT%H:%M:%S%z'\n",
+    "        )\n",
+    "    except FileNotFoundError as e:\n",
+    "        print(f\"Error: {e}. Skipping file {home_id}_raw_measurements.parquet.\")\n",
+    "        continue                "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/NeedForHeat_to_CSV.ipynb
+++ b/examples/NeedForHeat_to_CSV.ipynb
@@ -5,8 +5,8 @@
    "id": "b8e351d3-620f-45ea-82f0-18b8a8ebf2c5",
    "metadata": {},
    "source": [
-    "## Write to zipped CSV files\n",
-    "> WARNING: this might take hours!"
+    "# Write to zipped CSV files\n",
+    "> WARNING: this might take hours for large Parquet files!"
    ]
   },
   {
@@ -16,7 +16,7 @@
     "tags": []
    },
    "source": [
-    "### Write raw measurements per home to zipped CSV files"
+    "## Write raw measurements per home to zipped CSV files"
    ]
   },
   {
@@ -88,7 +88,7 @@
     "tags": []
    },
    "source": [
-    "### Write raw properties per home to zipped CSV files"
+    "## Write raw properties per home to zipped CSV files"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,19 +6,12 @@ pytz==2022.7.1
 tqdm==4.64.1
 setuptools==67.1.0
 ipympl==0.9.3
-pyarrow==11.0.0
-requests==2.28.2
+pyarrow==15.0.1
+requests==2.31.0
 matplotlib==3.6.3
 matplotlib-inline==0.1.6
 seaborn==0.12.2
 -e git+https://github.com/stephanpcpeters/HourlyHistoricWeather.git#egg=historicdutchweather
-
-## which database system is needed? seems broken
-
-## it used to be
 mysql-connector-python==8.0.32
 SQLAlchemy==2.0.3
 
-## however, recently pipreqs said:
-#db==0.1.1
-#mysql_connector_repackaged==0.3.1


### PR DESCRIPTION
I added capabilities to retrieve date for the REDUCEDHEATCARB project from a twomes_v2 database:

- A new function **get_needforheat_measurements()** in twomes-inverse-grey-box-analysis/data/measurements.py
-  twomes-inverse-grey-box-analysis/examples/**NeedForHeatExtractionBackup.ipynb**, new notebook for data extraction taks , which results in one total Parquet file and separate Parquet files for each home
- twomes-inverse-grey-box-analysis/examples/**NeedForHeat_Parquet_to_CSV.ipynb**, a new notebook for conversion of the generated Parquet files to zipped CSV files

NB These must be run JupyterLab notebook on the server, with proper access to a twomes_v2 database on a MariaDB container on the same server. Deploying using a stack is supported, but ay requires a bit of coordination.

As mentioned in twomes-inverse-grey-box-analysis/examples/NeedForHeatExtractionBackup.ipynb, proper handling of pseudonyms requires a separate pseudonym.xlsx, which is deliberately NOT included in this PR.
